### PR TITLE
Add support for MARK/SPACE parity on unix platforms if defined in termios.h.

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -353,15 +353,38 @@ VALUE sp_set_modem_params_impl(argc, argv, self)
       case EVEN:
          params.c_cflag |= PARENB;
          params.c_cflag &= ~PARODD;
+#ifdef CMSPAR
+         params.c_cflag &= ~CMSPAR;
+#endif
          break;
 
       case ODD:
          params.c_cflag |= PARENB;
          params.c_cflag |= PARODD;
+#ifdef CMSPAR
+         params.c_cflag &= ~CMSPAR;
+#endif
          break;
+
+#ifdef CMSPAR
+      case SPACE:
+         params.c_cflag |= PARENB;
+         params.c_cflag &= ~PARODD;
+         params.c_cflag |= CMSPAR;
+         break;
+
+      case MARK:
+         params.c_cflag |= PARENB;
+         params.c_cflag |= PARODD;
+         params.c_cflag |= CMSPAR;
+         break;
+#endif
 
       case NONE:
          params.c_cflag &= ~PARENB;
+#ifdef CMSPAR
+         params.c_cflag &= ~CMSPAR;
+#endif
          break;
 
       default:

--- a/ext/native/serialport.h
+++ b/ext/native/serialport.h
@@ -65,10 +65,10 @@ struct line_signals
    #endif
 
 #else
-   #define SPACE  0
-   #define MARK   0
    #define EVEN   1
    #define ODD    2
+   #define SPACE  3
+   #define MARK   4
 
    #define RB_SERIAL_EXPORT
 #endif


### PR DESCRIPTION
CMSPAR is not defined in POSIX, but works on Linux. Use #ifdef to check for it.
