### PR TITLE
stop using deprecated api

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -126,8 +126,7 @@ VALUE sp_create_impl(class, _port)
          break;
 
       case T_STRING:
-         Check_SafeStr(_port);
-         port = RSTRING_PTR(_port);
+         port = StringValueCStr(_port);
          break;
 
       default:

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -94,8 +94,7 @@ VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
          break;
 
       case T_STRING:
-         Check_SafeStr(_port);
-         str_port = RSTRING_PTR(_port);
+         str_port = StringValueCStr(_port);
 		 if (str_port[0] != '\\') /* Check for Win32 Device Namespace prefix "\\.\" */
 		 {
 			snprintf(port, sizeof(port) - 1, "\\\\.\\%s", str_port);


### PR DESCRIPTION
Hi,

The serialport gem won't compile on Ruby 2.2 because `Check_SafeStr` has been removed.  I've fixed those spots so it works on all rubys.
