### PR TITLE
Support baudrate > 1MBit on posix

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -263,7 +263,21 @@ VALUE sp_set_modem_params_impl(argc, argv, self)
 #ifdef B1000000
       case 1000000: data_rate = B1000000; break;
 #endif
-
+#ifdef B1500000
+      case 1500000: data_rate = B1500000; break;
+#endif
+#ifdef B2000000
+      case 2000000: data_rate = B2000000; break;
+#endif
+#ifdef B3000000
+      case 3000000: data_rate = B3000000; break;
+#endif
+#ifdef B3500000
+      case 3500000: data_rate = B3500000; break;
+#endif
+#ifdef B4000000
+      case 4000000: data_rate = B4000000; break;
+#endif
       default:
                    rb_raise(rb_eArgError, "unknown baud rate");
                    break;


### PR DESCRIPTION
termios.h defines baud rates up to 4MBit on my system. Add case conditionals to support these where available.
