### PR TITLE
Fix deprecated rb_secure call

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -110,7 +110,7 @@ VALUE sp_create_impl(class, _port)
    struct termios params;
 
    NEWOBJ(sp, struct RFile);
-   rb_secure(4);
+   rb_secure(3);
    OBJSETUP(sp, class, T_FILE);
    MakeOpenFile((VALUE) sp, fp);
 

--- a/serialport.gemspec
+++ b/serialport.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = "serialport"
   s.license = "GPL-2"
   s.version = SerialPort::VERSION
-  s.authors = ["Guillaume Pierronnet", "Alan Stern", "Daniel E. Shipton", "Tobin Richard", "Hector Parra", "Ryan C. Payne"]
+  s.authors = ["Guillaume Pierronnet", "Alan Stern", "Daniel E. Shipton", "Tobin Richard", "Hector Parra", "Ryan C. Payne", 'Aaron Ten Clay']
   s.summary = "Library for using RS-232 serial ports."
   s.description = "Ruby/SerialPort is a Ruby library that provides a class for using RS-232 serial ports."
   s.email = "hector@hectorparra.com"


### PR DESCRIPTION
Updated rb_secure call for compatibility with Ruby 2.
