### PR TITLE
Fixed XON/XOFF config bug on Linux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.3.3 => 07/15/2020:    [FIXED] 0x0D got translated to 0x0A under Linux
+
 1.3.2 => 01/06/2019:    [FIXED] 0x11/0x13 stripped out under Linux
 
 1.3.1 => 07/26/2014:    [FIXED] Ruby 2.2 support

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.3.2 => 01/06/2019:    [FIXED] 0x11/0x13 stripped out under Linux
+
 1.3.1 => 07/26/2014:    [FIXED] Ruby 2.2 support
                         [NEW] UNIX MARK/SPACE parity (CMSPAR) support
 

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -155,9 +155,12 @@ VALUE sp_create_impl(class, _port)
       rb_sys_fail(sTcgetattr);
    }
 
+   // clean oflag and iflag, you may get unexpected behaviour if any bit of iflag/oflag is set.
    params.c_oflag = 0;
+   params.c_iflag = 0;
+
    params.c_lflag = 0;
-   params.c_iflag &= ~(IXON | IXOFF | IXANY);
+   
    params.c_cflag |= CLOCAL | CREAD;
    params.c_cflag &= ~HUPCL;
 

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -162,7 +162,7 @@ VALUE sp_create_impl(class, _port)
    params.c_lflag = 0;
    
    params.c_cflag |= CLOCAL | CREAD;
-   params.c_cflag &= ~HUPCL;
+   params.c_cflag &= ~(HUPCL | CRTSCTS);  // default not use RTS/CTS hw flow control
 
    if (tcsetattr(fd, TCSANOW, &params) == -1)
    {

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -157,7 +157,7 @@ VALUE sp_create_impl(class, _port)
 
    params.c_oflag = 0;
    params.c_lflag = 0;
-   params.c_iflag &= (IXON | IXOFF | IXANY);
+   params.c_iflag &= ~(IXON | IXOFF | IXANY);
    params.c_cflag |= CLOCAL | CREAD;
    params.c_cflag &= ~HUPCL;
 

--- a/lib/serialport/version.rb
+++ b/lib/serialport/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SerialPort
-  VERSION = '1.3.4'
+  VERSION = '1.3.3'
 end

--- a/lib/serialport/version.rb
+++ b/lib/serialport/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SerialPort
-  VERSION = "1.3.2"
+  VERSION = '1.3.4'
 end

--- a/lib/serialport/version.rb
+++ b/lib/serialport/version.rb
@@ -1,3 +1,3 @@
 class SerialPort
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end


### PR DESCRIPTION
This fixed the issue of 0x11 in data stream is filtered out under linux.