### PR TITLE
Remove rb_secure calls because it is deprecated and being removed in Ruby 3.0

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -110,7 +110,6 @@ VALUE sp_create_impl(class, _port)
    struct termios params;
 
    NEWOBJ(sp, struct RFile);
-   rb_secure(4);
    OBJSETUP(sp, class, T_FILE);
    MakeOpenFile((VALUE) sp, fp);
 

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -76,7 +76,6 @@ VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
    DCB dcb;
 
    NEWOBJ(sp, struct RFile);
-   rb_secure(4);
    OBJSETUP(sp, class, T_FILE);
    MakeOpenFile((VALUE) sp, fp);
 


### PR DESCRIPTION
This gem calls `rb_secure`, which means that when I run it in Ruby 2.7.4, I get these warnings:

```text
/home/david/.gem/ruby/2.7.4/gems/serialport-1.3.1/lib/serialport.rb:25: warning: rb_safe_level_2_warning will be removed in Ruby 3.0
/home/david/.gem/ruby/2.7.4/gems/serialport-1.3.1/lib/serialport.rb:25: warning: rb_secure will be removed in Ruby 3.0
```

This pull request fixes the warning by simply removing the calls to `rb_secure`.  I haven't tested the gem in Ruby 3, but this change should also help fix issue #69.

If anyone is using this gem in an application where they were using the Ruby [Safe Levels](https://ruby-doc.com/docs/ProgrammingRuby/html/taint.html) feature, which is going away in Ruby 3, this change could make their code less safe.