### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.3.2 => 09/29/2021:    [FIXED] Ruby 3.0 support
+
 1.3.1 => 07/26/2014:    [FIXED] Ruby 2.2 support
                         [NEW] UNIX MARK/SPACE parity (CMSPAR) support
 


### PR DESCRIPTION
The changelog entry for 1.3.2 has been missing. This PR is adding a very simple one.