### PR TITLE
posix_serialport_impl.c: error: incompatible pointer to integer

### DIFF
--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -110,7 +110,7 @@ VALUE sp_create_impl(class, _port)
    struct termios params;
 
    NEWOBJ(sp, struct RFile);
-   OBJSETUP(sp, class, T_FILE);
+   OBJSETUP((VALUE)sp, class, T_FILE);
    MakeOpenFile((VALUE) sp, fp);
 
    switch(TYPE(_port))


### PR DESCRIPTION
Clang 15 has enabled -Werror=int-conversion by default. Hence, we now get

posix_serialport_impl.c:113:13: error: incompatible pointer to integer conversion passing 'struct RFile *' to parameter of type 'VALUE' (aka 'unsigned long') [-Wint-conversion]
OBJSETUP(sp, class, T_FILE);
^~
This commit should fix this build error.

Bug: https://bugs.gentoo.org/883127