### PR TITLE
Update serialport to be compatible to newer ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-source "http://gems.github.com"
+
 gemspec

--- a/ext/native/extconf.rb
+++ b/ext/native/extconf.rb
@@ -10,4 +10,6 @@ if !(os == 'mswin' or os == 'bccwin' or os == 'mingw')
   exit(1) if not have_header("termios.h") or not have_header("unistd.h")
 end
 
+have_func("rb_io_open_descriptor") # ruby-3.3+
+
 create_makefile('serialport')

--- a/ext/native/extconf.rb
+++ b/ext/native/extconf.rb
@@ -10,6 +10,7 @@ if !(os == 'mswin' or os == 'bccwin' or os == 'mingw')
   exit(1) if not have_header("termios.h") or not have_header("unistd.h")
 end
 
+have_func("rb_io_descriptor") # ruby-3.1+
 have_func("rb_io_open_descriptor") # ruby-3.3+
 
 create_makefile('serialport')

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -64,17 +64,9 @@ static char sIoctl[] = "ioctl";
 int get_fd_helper(obj)
    VALUE obj;
 {
-#ifdef HAVE_RUBY_IO_H
    rb_io_t *fptr;
-#else
-   OpenFile *fptr;
-#endif
    GetOpenFile(obj, fptr);
-#ifdef HAVE_RUBY_IO_H
    return (fptr->fd);
-#else
-   return (fileno(fptr->f));
-#endif
 }
 
 VALUE sp_create_impl(class, _port)

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -80,12 +80,6 @@ int get_fd_helper(obj)
 VALUE sp_create_impl(class, _port)
    VALUE class, _port;
 {
-#ifdef HAVE_RUBY_IO_H
-   rb_io_t *fp;
-#else
-   OpenFile *fp;
-#endif
-
    int fd;
    int num_port;
    char *port;
@@ -108,10 +102,7 @@ VALUE sp_create_impl(class, _port)
 #endif
    };
    struct termios params;
-
-   NEWOBJ(sp, struct RFile);
-   OBJSETUP(sp, class, T_FILE);
-   MakeOpenFile((VALUE) sp, fp);
+   VALUE sp;
 
    switch(TYPE(_port))
    {
@@ -166,14 +157,9 @@ VALUE sp_create_impl(class, _port)
       rb_sys_fail(sTcsetattr);
    }
 
-#ifdef HAVE_RUBY_IO_H
-   fp->fd = fd;
-#else
-   fp->f = rb_fdopen(fd, "r+");
-#endif
-   fp->mode = FMODE_READWRITE | FMODE_SYNC;
+   sp = rb_io_open_descriptor(class, fd, FMODE_READWRITE | FMODE_SYNC, Qnil, Qnil, NULL);
 
-   return (VALUE) sp;
+   return sp;
 }
 
 VALUE sp_set_modem_params_impl(argc, argv, self)

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -76,8 +76,8 @@ VALUE sp_create_impl(VALUE class, VALUE _port)
 {
    int fd;
    int num_port;
-   char *port;
-   char *ports[] = {
+   const char *port;
+   const char *ports[] = {
 #if defined(OS_LINUX) || defined(OS_CYGWIN)
       "/dev/ttyS0", "/dev/ttyS1", "/dev/ttyS2", "/dev/ttyS3",
       "/dev/ttyS4", "/dev/ttyS5", "/dev/ttyS6", "/dev/ttyS7"

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -75,7 +75,7 @@ int get_fd_helper(VALUE io)
 VALUE sp_create_impl(VALUE class, VALUE _port)
 {
    int fd;
-   int num_port;
+   long num_port;
    const char *port;
    const char *ports[] = {
 #if defined(OS_LINUX) || defined(OS_CYGWIN)
@@ -101,8 +101,8 @@ VALUE sp_create_impl(VALUE class, VALUE _port)
    switch(TYPE(_port))
    {
       case T_FIXNUM:
-         num_port = FIX2INT(_port);
-         if (num_port < 0 || num_port > sizeof(ports) / sizeof(ports[0]))
+         num_port = FIX2LONG(_port);
+         if (num_port < 0 || num_port > (long)(sizeof(ports) / sizeof(ports[0])))
          {
             rb_raise(rb_eArgError, "illegal port number");
          }

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -61,12 +61,15 @@ static char sTcsetattr[] = "tcsetattr";
 static char sIoctl[] = "ioctl";
 
 
-int get_fd_helper(obj)
-   VALUE obj;
+int get_fd_helper(VALUE io)
 {
-   rb_io_t *fptr;
-   GetOpenFile(obj, fptr);
-   return (fptr->fd);
+#ifdef HAVE_RB_IO_DESCRIPTOR
+  return rb_io_descriptor(io);
+#else
+  rb_io_t* fp;
+  GetOpenFile(io, fp);
+  return fp->fd;
+#endif
 }
 
 VALUE sp_create_impl(class, _port)

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -602,16 +602,14 @@ VALUE sp_get_read_timeout_impl(VALUE self)
    return INT2FIX(params.c_cc[VTIME] * 100);
 }
 
-VALUE sp_set_write_timeout_impl(VALUE self, VALUE val)
+NORETURN(VALUE sp_set_write_timeout_impl(VALUE self, VALUE val))
 {
    rb_notimplement();
-   return self;
 }
 
-VALUE sp_get_write_timeout_impl(VALUE self)
+NORETURN(VALUE sp_get_write_timeout_impl(VALUE self))
 {
    rb_notimplement();
-   return self;
 }
 
 VALUE sp_break_impl(VALUE self, VALUE time)

--- a/ext/native/posix_serialport_impl.c
+++ b/ext/native/posix_serialport_impl.c
@@ -72,8 +72,7 @@ int get_fd_helper(VALUE io)
 #endif
 }
 
-VALUE sp_create_impl(class, _port)
-   VALUE class, _port;
+VALUE sp_create_impl(VALUE class, VALUE _port)
 {
    int fd;
    int num_port;
@@ -157,9 +156,7 @@ VALUE sp_create_impl(class, _port)
    return sp;
 }
 
-VALUE sp_set_modem_params_impl(argc, argv, self)
-   int argc;
-   VALUE *argv, self;
+VALUE sp_set_modem_params_impl(int argc, VALUE *argv, VALUE self)
 {
    int fd;
    struct termios params;
@@ -380,9 +377,7 @@ VALUE sp_set_modem_params_impl(argc, argv, self)
    return argv[0];
 }
 
-void get_modem_params_impl(self, mp)
-   VALUE self;
-   struct modem_params *mp;
+void get_modem_params_impl(VALUE self, struct modem_params *mp)
 {
    int fd;
    struct termios params;
@@ -474,8 +469,7 @@ void get_modem_params_impl(self, mp)
    }
 }
 
-VALUE sp_set_flow_control_impl(self, val)
-   VALUE self, val;
+VALUE sp_set_flow_control_impl(VALUE self, VALUE val)
 {
    int fd;
    int flowc;
@@ -521,8 +515,7 @@ VALUE sp_set_flow_control_impl(self, val)
    return val;
 }
 
-VALUE sp_get_flow_control_impl(self)
-   VALUE self;
+VALUE sp_get_flow_control_impl(VALUE self)
 {
    int ret;
    int fd;
@@ -551,8 +544,7 @@ VALUE sp_get_flow_control_impl(self)
    return INT2FIX(ret);
 }
 
-VALUE sp_set_read_timeout_impl(self, val)
-   VALUE self, val;
+VALUE sp_set_read_timeout_impl(VALUE self, VALUE val)
 {
    int timeout;
    int fd;
@@ -591,8 +583,7 @@ VALUE sp_set_read_timeout_impl(self, val)
    return val;
 }
 
-VALUE sp_get_read_timeout_impl(self)
-   VALUE self;
+VALUE sp_get_read_timeout_impl(VALUE self)
 {
    int fd;
    struct termios params;
@@ -611,22 +602,19 @@ VALUE sp_get_read_timeout_impl(self)
    return INT2FIX(params.c_cc[VTIME] * 100);
 }
 
-VALUE sp_set_write_timeout_impl(self, val)
-   VALUE self, val;
+VALUE sp_set_write_timeout_impl(VALUE self, VALUE val)
 {
    rb_notimplement();
    return self;
 }
 
-VALUE sp_get_write_timeout_impl(self)
-   VALUE self;
+VALUE sp_get_write_timeout_impl(VALUE self)
 {
    rb_notimplement();
    return self;
 }
 
-VALUE sp_break_impl(self, time)
-   VALUE self, time;
+VALUE sp_break_impl(VALUE self, VALUE time)
 {
    int fd;
 
@@ -642,9 +630,7 @@ VALUE sp_break_impl(self, time)
    return Qnil;
 }
 
-void get_line_signals_helper_impl(obj, ls)
-   VALUE obj;
-   struct line_signals *ls;
+void get_line_signals_helper_impl(VALUE obj, struct line_signals *ls)
 {
    int fd, status;
 
@@ -663,9 +649,7 @@ void get_line_signals_helper_impl(obj, ls)
    ls->ri  = (status & TIOCM_RI ? 1 : 0);
 }
 
-VALUE set_signal_impl(obj, val, sig)
-   VALUE obj,val;
-   int sig;
+VALUE set_signal_impl(VALUE obj, VALUE val, int sig)
 {
    int status;
    int fd;
@@ -702,20 +686,17 @@ VALUE set_signal_impl(obj, val, sig)
    return val;
 }
 
-VALUE sp_set_rts_impl(self, val)
-   VALUE self, val;
+VALUE sp_set_rts_impl(VALUE self, VALUE val)
 {
    return set_signal_impl(self, val, TIOCM_RTS);
 }
 
-VALUE sp_set_dtr_impl(self, val)
-   VALUE self, val;
+VALUE sp_set_dtr_impl(VALUE self, VALUE val)
 {
    return set_signal_impl(self, val, TIOCM_DTR);
 }
 
-VALUE sp_get_rts_impl(self)
-   VALUE self;
+VALUE sp_get_rts_impl(VALUE self)
 {
    struct line_signals ls;
 
@@ -723,8 +704,7 @@ VALUE sp_get_rts_impl(self)
    return INT2FIX(ls.rts);
 }
 
-VALUE sp_get_dtr_impl(self)
-   VALUE self;
+VALUE sp_get_dtr_impl(VALUE self)
 {
    struct line_signals ls;
 
@@ -733,8 +713,7 @@ VALUE sp_get_dtr_impl(self)
    return INT2FIX(ls.dtr);
 }
 
-VALUE sp_flush_input_data_impl(self)
-VALUE self;
+VALUE sp_flush_input_data_impl(VALUE self)
 {
 	int fd;
 	int ret;
@@ -749,8 +728,7 @@ VALUE self;
 	return Qtrue;
 }
 
-VALUE sp_flush_output_data_impl(self)
-VALUE self;
+VALUE sp_flush_output_data_impl(VALUE self)
 {
 	int fd;
 	int ret;

--- a/ext/native/serialport.c
+++ b/ext/native/serialport.c
@@ -20,6 +20,27 @@ VALUE cSerialPort; /* serial port class */
 VALUE sBaud, sDataBits, sStopBits, sParity; /* strings */
 VALUE sRts, sDtr, sCts, sDsr, sDcd, sRi;
 
+
+#ifndef HAVE_RB_IO_OPEN_DESCRIPTOR
+VALUE
+io_open_descriptor_fallback(VALUE klass, int descriptor, int mode, VALUE path, VALUE timeout, void *encoding)
+{
+    VALUE arguments[2] = {
+        (rb_update_max_fd(descriptor), INT2NUM(descriptor)),
+        INT2FIX(mode),
+    };
+
+    VALUE self = rb_class_new_instance(2, arguments, klass);
+
+    rb_io_t *fptr;
+    GetOpenFile(self, fptr);
+    fptr->pathv = path;
+    fptr->mode |= mode;
+
+    return self;
+}
+#endif
+
 /*
  * @api private
  *

--- a/ext/native/serialport.c
+++ b/ext/native/serialport.c
@@ -47,8 +47,7 @@ io_open_descriptor_fallback(VALUE klass, int descriptor, int mode, VALUE path, V
  * @see SerialPort#new
  * @see SerialPort#open
  */
-static VALUE sp_create(class, _port)
-   VALUE class, _port;
+static VALUE sp_create(VALUE class, VALUE _port)
 {
    return sp_create_impl(class, _port);
 }
@@ -68,7 +67,7 @@ static VALUE sp_create(class, _port)
  *    (baud, data_bits = 8, stop_bits = 1, parity = (previous_databits == 8 ? NONE : EVEN))
  * A baudrate of nil will keep the old value.
  * The default parity depends on the number of databits configured before this function call.
- * 
+ *
  * @overload set_modem_params(baud, data_bits, stop_bits, parity)
  *    @param baud [Integer] the baud rate
  *    @param data_bits [Integer] the number of data bits
@@ -80,9 +79,7 @@ static VALUE sp_create(class, _port)
  * @return [Hash] the original paramters
  * @raise [ArgumentError] if values are invalide or unsupported
  */
-static VALUE sp_set_modem_params(argc, argv, self)
-   int argc;
-   VALUE *argv, self;
+static VALUE sp_set_modem_params(int argc, VALUE *argv, VALUE self)
 {
    return sp_set_modem_params_impl(argc, argv, self);
 }
@@ -94,20 +91,18 @@ static VALUE sp_set_modem_params(argc, argv, self)
  * @return [nil]
  * @note (POSIX) this value is very approximate
  */
-static VALUE sp_break(self, time)
-   VALUE self, time;
+static VALUE sp_break(VALUE self, VALUE time)
 {
    return sp_break_impl(self, time);
 }
 
 /*
- * Get the state of the DTR line 
+ * Get the state of the DTR line
  *
  * @note (Windows) DTR is not available
  * @return [Integer] the state of DTR line, 0 or 1
  */
-static VALUE sp_get_dtr(self)
-   VALUE self;
+static VALUE sp_get_dtr(VALUE self)
 {
    return sp_get_dtr_impl(self);
 }
@@ -118,8 +113,7 @@ static VALUE sp_get_dtr(self)
  * @return [Integer] the flow control flag
  * @see SerialPort#set_flow_control
  */
-static VALUE sp_get_flow_control(self)
-   VALUE self;
+static VALUE sp_get_flow_control(VALUE self)
 {
    return sp_get_flow_control_impl(self);
 }
@@ -130,8 +124,7 @@ static VALUE sp_get_flow_control(self)
  * @return [Integer] the read timeout, in milliseconds
  * @see SerialPort#set_read_timeout
  */
-static VALUE sp_get_read_timeout(self)
-   VALUE self;
+static VALUE sp_get_read_timeout(VALUE self)
 {
    return sp_get_read_timeout_impl(self);
 }
@@ -142,8 +135,7 @@ static VALUE sp_get_read_timeout(self)
  * @return [Integer] the state of RTS line, 0 or 1
  * @note (Windows) RTS is not available
  */
-static VALUE sp_get_rts(self)
-   VALUE self;
+static VALUE sp_get_rts(VALUE self)
 {
    return sp_get_rts_impl(self);
 }
@@ -154,8 +146,7 @@ static VALUE sp_get_rts(self)
  * @return [Integer] the write timeout, in milliseconds
  * @note (POSIX) write timeouts are not implemented
  */
-static VALUE sp_get_write_timeout(self)
-   VALUE self;
+static VALUE sp_get_write_timeout(VALUE self)
 {
    return sp_get_write_timeout_impl(self);
 }
@@ -166,8 +157,7 @@ static VALUE sp_get_write_timeout(self)
  * @param val [Integer] the desired state of the DTR line, 0 or 1
  * @return [Integer] the original +val+ parameter
  */
-static VALUE sp_set_dtr(self, val)
-   VALUE self, val;
+static VALUE sp_set_dtr(VALUE self, VALUE val)
 {
    return sp_set_dtr_impl(self, val);
 }
@@ -182,8 +172,7 @@ static VALUE sp_set_dtr(self, val)
  * @note SerialPort::HARD uses RTS/CTS handshaking.
  *    DSR/DTR is not supported.
  */
-static VALUE sp_set_flow_control(self, val)
-   VALUE self, val;
+static VALUE sp_set_flow_control(VALUE self, VALUE val)
 {
    return sp_set_flow_control_impl(self, val);
 }
@@ -200,8 +189,7 @@ static VALUE sp_set_flow_control(self, val)
  * @return [Integer] the original +timeout+ parameter
  * @note Read timeouts don't mix well with multi-threading
  */
-static VALUE sp_set_read_timeout(self, val)
-   VALUE self, val;
+static VALUE sp_set_read_timeout(VALUE self, VALUE val)
 {
    return sp_set_read_timeout_impl(self, val);
 }
@@ -212,8 +200,7 @@ static VALUE sp_set_read_timeout(self, val)
  * @param val [Integer] the state of RTS line, 0 or 1
  * @return [Integer] the original +val+ parameter
  */
-static VALUE sp_set_rts(self, val)
-   VALUE self, val;
+static VALUE sp_set_rts(VALUE self, VALUE val)
 {
    return sp_set_rts_impl(self, val);
 }
@@ -225,8 +212,7 @@ static VALUE sp_set_rts(self, val)
  * @return [Integer] the original +val+ parameter
  * @note (POSIX) write timeouts are not implemented
  */
-static VALUE sp_set_write_timeout(self, val)
-   VALUE self, val;
+static VALUE sp_set_write_timeout(VALUE self, VALUE val)
 {
    return sp_set_write_timeout_impl(self, val);
 }
@@ -234,9 +220,7 @@ static VALUE sp_set_write_timeout(self, val)
 /*
  * @private helper
  */
-static void get_modem_params(self, mp)
-   VALUE self;
-   struct modem_params *mp;
+static void get_modem_params(VALUE self, struct modem_params *mp)
 {
    get_modem_params_impl(self, mp);
 }
@@ -248,8 +232,7 @@ static void get_modem_params(self, mp)
  * @return [Integer] the original +data_rate+ parameter
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_set_data_rate(self, data_rate)
-   VALUE self, data_rate;
+static VALUE sp_set_data_rate(VALUE self, VALUE data_rate)
 {
    VALUE argv[4];
 
@@ -267,8 +250,7 @@ static VALUE sp_set_data_rate(self, data_rate)
  * @return [Integer] the original +data_bits+ parameter
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_set_data_bits(self, data_bits)
-   VALUE self, data_bits;
+static VALUE sp_set_data_bits(VALUE self, VALUE data_bits)
 {
    VALUE argv[4];
 
@@ -286,8 +268,7 @@ static VALUE sp_set_data_bits(self, data_bits)
  * @return [Integer] the original +stop_bits+ parameter
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_set_stop_bits(self, stop_bits)
-   VALUE self, stop_bits;
+static VALUE sp_set_stop_bits(VALUE self, VALUE stop_bits)
 {
    VALUE argv[4];
 
@@ -305,8 +286,7 @@ static VALUE sp_set_stop_bits(self, stop_bits)
  * @return [Integer] the original +parity+ parameter
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_set_parity(self, parity)
-   VALUE self, parity;
+static VALUE sp_set_parity(VALUE self, VALUE parity)
 {
    VALUE argv[4];
 
@@ -323,8 +303,7 @@ static VALUE sp_set_parity(self, parity)
  * @return [Integer] the current baud rate
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_get_data_rate(self)
-   VALUE self;
+static VALUE sp_get_data_rate(VALUE self)
 {
    struct modem_params mp;
 
@@ -339,8 +318,7 @@ static VALUE sp_get_data_rate(self)
  * @return [Integer] the current number of data bits
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_get_data_bits(self)
-   VALUE self;
+static VALUE sp_get_data_bits(VALUE self)
 {
    struct modem_params mp;
 
@@ -355,8 +333,7 @@ static VALUE sp_get_data_bits(self)
  * @return [Integer] the current number of stop bits
  * @see SerialPort#set_modem_params for details
  */
-static VALUE sp_get_stop_bits(self)
-   VALUE self;
+static VALUE sp_get_stop_bits(VALUE self)
 {
    struct modem_params mp;
 
@@ -371,8 +348,7 @@ static VALUE sp_get_stop_bits(self)
  * @return [Integer] the current parity
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_get_parity(self)
-   VALUE self;
+static VALUE sp_get_parity(VALUE self)
 {
    struct modem_params mp;
 
@@ -387,8 +363,7 @@ static VALUE sp_get_parity(self)
  * @return [Hash] the serial port configuration
  * @see SerialPort#set_modem_params
  */
-static VALUE sp_get_modem_params(self)
-   VALUE self;
+static VALUE sp_get_modem_params(VALUE self)
 {
    struct modem_params mp;
    VALUE hash;
@@ -408,9 +383,7 @@ static VALUE sp_get_modem_params(self)
 /*
  * @api private
  */
-void get_line_signals_helper(obj, ls)
-   VALUE obj;
-   struct line_signals *ls;
+void get_line_signals_helper(VALUE obj, struct line_signals *ls)
 {
    get_line_signals_helper_impl(obj, ls);
 }
@@ -421,8 +394,7 @@ void get_line_signals_helper(obj, ls)
  * @return [Integer] the state of the CTS line, 0 or 1
  * @see SerialPort#get_signals
  */
-static VALUE sp_get_cts(self)
-   VALUE self;
+static VALUE sp_get_cts(VALUE self)
 {
    struct line_signals ls;
 
@@ -437,8 +409,7 @@ static VALUE sp_get_cts(self)
  * @return [Integer] the state of the DSR line, 0 or 1
  * @see SerialPort#get_signals
  */
-static VALUE sp_get_dsr(self)
-   VALUE self;
+static VALUE sp_get_dsr(VALUE self)
 {
    struct line_signals ls;
 
@@ -453,8 +424,7 @@ static VALUE sp_get_dsr(self)
  * @return [Integer] the state of the DCD line, 0 or 1
  * @see SerialPort#get_signals
  */
-static VALUE sp_get_dcd(self)
-   VALUE self;
+static VALUE sp_get_dcd(VALUE self)
 {
    struct line_signals ls;
 
@@ -469,8 +439,7 @@ static VALUE sp_get_dcd(self)
  * @return [Integer] the state of the RI line, 0 or 1
  * @see SerialPort#get_signals
  */
-static VALUE sp_get_ri(self)
-   VALUE self;
+static VALUE sp_get_ri(VALUE self)
 {
    struct line_signals ls;
 
@@ -488,8 +457,7 @@ static VALUE sp_get_ri(self)
  * @note (Windows) the rts and dtr values are not included
  * @note This method is implemented as both SerialPort#signals and SerialPort#get_signals
  */
-static VALUE sp_signals(self)
-   VALUE self;
+static VALUE sp_signals(VALUE self)
 {
    struct line_signals ls;
    VALUE hash;
@@ -515,8 +483,7 @@ static VALUE sp_signals(self)
  *
  * @return [Boolean] true on success or false if an error occurs.
  */
-static VALUE sp_flush_input_data(self)
-   VALUE self;
+static VALUE sp_flush_input_data(VALUE self)
 {
    return sp_flush_input_data_impl(self);
 }
@@ -526,14 +493,13 @@ static VALUE sp_flush_input_data(self)
  *
  * @return [Boolean] true on success or false if an error occurs.
  */
-static VALUE sp_flush_output_data(self)
-   VALUE self;
+static VALUE sp_flush_output_data(VALUE self)
 {
    return sp_flush_output_data_impl(self);
 }
 
 
-void Init_serialport()
+void Init_serialport(void)
 {
    sBaud = rb_str_new2("baud");
    sDataBits = rb_str_new2("data_bits");

--- a/ext/native/serialport.h
+++ b/ext/native/serialport.h
@@ -28,6 +28,11 @@
    #include <rubyio.h>
 #endif
 
+#ifndef HAVE_RB_IO_OPEN_DESCRIPTOR
+VALUE io_open_descriptor_fallback(VALUE klass, int descriptor, int mode, VALUE path, VALUE timeout, void *encoding);
+#define rb_io_open_descriptor io_open_descriptor_fallback
+#endif
+
 struct modem_params
 {
    int data_rate;

--- a/ext/native/serialport.h
+++ b/ext/native/serialport.h
@@ -22,11 +22,7 @@
 #define _RUBY_SERIAL_PORT_H_
 
 #include <ruby.h>    /* ruby inclusion */
-#ifdef HAVE_RUBY_IO_H      /* ruby io inclusion */
-   #include <ruby/io.h>
-#else
-   #include <rubyio.h>
-#endif
+#include <ruby/io.h>
 
 #ifndef HAVE_RB_IO_OPEN_DESCRIPTOR
 VALUE io_open_descriptor_fallback(VALUE klass, int descriptor, int mode, VALUE path, VALUE timeout, void *encoding);
@@ -61,14 +57,7 @@ struct line_signals
    #define EVEN   EVENPARITY
    #define ODD    ODDPARITY
 
-   #ifndef RB_SERIAL_EXPORT
-	 #ifndef HAVE_RUBY_IO_H
-     	#define RB_SERIAL_EXPORT __declspec(dllexport)
-	 #else
-		#define RB_SERIAL_EXPORT
-	 #endif
-   #endif
-
+   #define RB_SERIAL_EXPORT
 #else
    #define EVEN   1
    #define ODD    2

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -62,22 +62,14 @@ static void _rb_win32_fail(const char *function_call) {
 VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
    VALUE class, _port;
 {
-#ifdef HAVE_RUBY_IO_H
-   rb_io_t *fp;
-#else
-   OpenFile *fp;
-#endif
    int fd;
    HANDLE fh;
    int num_port;
    char *str_port;
    char port[260]; /* Windows XP MAX_PATH. See http://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx */
+   VALUE sp;
 
    DCB dcb;
-
-   NEWOBJ(sp, struct RFile);
-   OBJSETUP(sp, class, T_FILE);
-   MakeOpenFile((VALUE) sp, fp);
 
    switch(TYPE(_port))
    {
@@ -148,13 +140,8 @@ VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
    }
 
    errno = 0;
-   fp->mode = FMODE_READWRITE | FMODE_BINMODE | FMODE_SYNC;
-#ifdef HAVE_RUBY_IO_H
-   fp->fd = fd;
-#else
-   fp->f = fdopen(fd, "rb+");
-#endif
-   return (VALUE) sp;
+   sp = rb_io_open_descriptor(class, fd, FMODE_READWRITE | FMODE_BINMODE | FMODE_SYNC, Qnil, Qnil, NULL);
+   return sp;
 }
 
 VALUE RB_SERIAL_EXPORT sp_set_modem_params_impl(argc, argv, self)

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -36,25 +36,17 @@ static char sSetCommTimeouts[] = "SetCommTimeouts";
 static HANDLE get_handle_helper(obj)
    VALUE obj;
 {
-#ifdef HAVE_RUBY_IO_H
    rb_io_t *fptr;
-#else
-   OpenFile *fptr;
-#endif
 
    GetOpenFile(obj, fptr);
-#ifdef HAVE_RUBY_IO_H
    return (HANDLE) _get_osfhandle(fptr->fd);
-#else
-   return (HANDLE) _get_osfhandle(fileno(fptr->f));
-#endif
 }
 
 /* hack to work around the fact that Ruby doesn't use GetLastError? */
 static void _rb_win32_fail(const char *function_call) {
   rb_raise(
-    rb_eRuntimeError, 
-    "%s failed: GetLastError returns %d", 
+    rb_eRuntimeError,
+    "%s failed: GetLastError returns %d",
     function_call, GetLastError( )
   );
 }

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -33,13 +33,15 @@ static char sGetCommTimeouts[] = "GetCommTimeouts";
 static char sSetCommTimeouts[] = "SetCommTimeouts";
 
 
-static HANDLE get_handle_helper(obj)
-   VALUE obj;
+static HANDLE get_handle_helper(VALUE io)
 {
-   rb_io_t *fptr;
-
-   GetOpenFile(obj, fptr);
-   return (HANDLE) _get_osfhandle(fptr->fd);
+#ifdef HAVE_RB_IO_DESCRIPTOR
+  return (HANDLE) _get_osfhandle(rb_io_descriptor(io));
+#else
+  rb_io_t* fp;
+  GetOpenFile(io, fp);
+  return (HANDLE) _get_osfhandle(fp->fd);
+#endif
 }
 
 /* hack to work around the fact that Ruby doesn't use GetLastError? */

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -53,8 +53,7 @@ static void _rb_win32_fail(const char *function_call) {
   );
 }
 
-VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
-   VALUE class, _port;
+VALUE RB_SERIAL_EXPORT sp_create_impl(VALUE class, VALUE _port)
 {
    int fd;
    HANDLE fh;
@@ -138,9 +137,7 @@ VALUE RB_SERIAL_EXPORT sp_create_impl(class, _port)
    return sp;
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_modem_params_impl(argc, argv, self)
-   int argc;
-   VALUE *argv, self;
+VALUE RB_SERIAL_EXPORT sp_set_modem_params_impl(int argc, VALUE *argv, VALUE self)
 {
    HANDLE fh;
    DCB dcb;
@@ -275,9 +272,7 @@ VALUE RB_SERIAL_EXPORT sp_set_modem_params_impl(argc, argv, self)
    return argv[0];
 }
 
-void RB_SERIAL_EXPORT get_modem_params_impl(self, mp)
-   VALUE self;
-   struct modem_params *mp;
+void RB_SERIAL_EXPORT get_modem_params_impl(VALUE self, struct modem_params *mp)
 {
    HANDLE fh;
    DCB dcb;
@@ -295,8 +290,7 @@ void RB_SERIAL_EXPORT get_modem_params_impl(self, mp)
    mp->parity = dcb.Parity;
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_flow_control_impl(self, val)
-   VALUE self, val;
+VALUE RB_SERIAL_EXPORT sp_set_flow_control_impl(VALUE self, VALUE val)
 {
    HANDLE fh;
    int flowc;
@@ -340,8 +334,7 @@ VALUE RB_SERIAL_EXPORT sp_set_flow_control_impl(self, val)
    return val;
 }
 
-VALUE RB_SERIAL_EXPORT sp_get_flow_control_impl(self)
-   VALUE self;
+VALUE RB_SERIAL_EXPORT sp_get_flow_control_impl(VALUE self)
 {
    HANDLE fh;
    int ret;
@@ -368,8 +361,7 @@ VALUE RB_SERIAL_EXPORT sp_get_flow_control_impl(self)
    return INT2FIX(ret);
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_read_timeout_impl(self, val)
-   VALUE self, val;
+VALUE RB_SERIAL_EXPORT sp_set_read_timeout_impl(VALUE self, VALUE val)
 {
    int timeout;
    HANDLE fh;
@@ -411,8 +403,7 @@ VALUE RB_SERIAL_EXPORT sp_set_read_timeout_impl(self, val)
    return val;
 }
 
-VALUE RB_SERIAL_EXPORT sp_get_read_timeout_impl(self)
-   VALUE self;
+VALUE RB_SERIAL_EXPORT sp_get_read_timeout_impl(VALUE self)
 {
    HANDLE fh;
    COMMTIMEOUTS ctout;
@@ -434,8 +425,7 @@ VALUE RB_SERIAL_EXPORT sp_get_read_timeout_impl(self)
    return INT2FIX(ctout.ReadTotalTimeoutConstant);
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_write_timeout_impl(self, val)
-   VALUE self, val;
+VALUE RB_SERIAL_EXPORT sp_set_write_timeout_impl(VALUE self, VALUE val)
 {
    int timeout;
    HANDLE fh;
@@ -469,8 +459,7 @@ VALUE RB_SERIAL_EXPORT sp_set_write_timeout_impl(self, val)
    return val;
 }
 
-VALUE RB_SERIAL_EXPORT sp_get_write_timeout_impl(self)
-   VALUE self;
+VALUE RB_SERIAL_EXPORT sp_get_write_timeout_impl(VALUE self)
 {
    HANDLE fh;
    COMMTIMEOUTS ctout;
@@ -484,8 +473,7 @@ VALUE RB_SERIAL_EXPORT sp_get_write_timeout_impl(self)
    return INT2FIX(ctout.WriteTotalTimeoutMultiplier);
 }
 
-static void delay_ms(time)
-   int time;
+static void delay_ms(int time)
 {
    HANDLE ev;
 
@@ -503,8 +491,7 @@ static void delay_ms(time)
    CloseHandle(ev);
 }
 
-VALUE RB_SERIAL_EXPORT sp_break_impl(self, time)
-   VALUE self, time;
+VALUE RB_SERIAL_EXPORT sp_break_impl(VALUE self, VALUE time)
 {
    HANDLE fh;
 
@@ -522,9 +509,7 @@ VALUE RB_SERIAL_EXPORT sp_break_impl(self, time)
    return Qnil;
 }
 
-void RB_SERIAL_EXPORT get_line_signals_helper_impl(obj, ls)
-   VALUE obj;
-   struct line_signals *ls;
+void RB_SERIAL_EXPORT get_line_signals_helper_impl(VALUE obj, struct line_signals *ls)
 {
    HANDLE fh;
    unsigned long status; /* DWORD */
@@ -541,9 +526,7 @@ void RB_SERIAL_EXPORT get_line_signals_helper_impl(obj, ls)
    ls->ri  = (status & MS_RING_ON ? 1 : 0);
 }
 
-static VALUE set_signal(obj, val, sigoff, sigon)
-   VALUE obj,val;
-   int sigoff, sigon;
+static VALUE set_signal(VALUE obj, VALUE val, int sigoff, int sigon)
 {
    HANDLE fh;
    int set, sig;
@@ -573,27 +556,23 @@ static VALUE set_signal(obj, val, sigoff, sigon)
    return val;
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_rts_impl(self, val)
-   VALUE self, val;
+VALUE RB_SERIAL_EXPORT sp_set_rts_impl(VALUE self, VALUE val)
 {
    return set_signal(self, val, CLRRTS, SETRTS);
 }
 
-VALUE RB_SERIAL_EXPORT sp_set_dtr_impl(self, val)
-   VALUE self, val;
+VALUE RB_SERIAL_EXPORT sp_set_dtr_impl(VALUE self, VALUE val)
 {
    return set_signal(self, val, CLRDTR, SETDTR);
 }
 
-VALUE RB_SERIAL_EXPORT sp_get_rts_impl(self)
-   VALUE self;
+VALUE RB_SERIAL_EXPORT sp_get_rts_impl(VALUE self)
 {
    rb_notimplement();
    return self;
 }
 
-VALUE RB_SERIAL_EXPORT sp_get_dtr_impl(self)
-   VALUE self;
+VALUE RB_SERIAL_EXPORT sp_get_dtr_impl(VALUE self)
 {
    rb_notimplement();
    return self;
@@ -601,8 +580,7 @@ VALUE RB_SERIAL_EXPORT sp_get_dtr_impl(self)
 
 #define PURGE_RXABORT 0x02
 #define PURGE_RXCLEAR 0x08
-VALUE RB_SERIAL_EXPORT sp_flush_input_data_impl(self)
-	VALUE self;
+VALUE RB_SERIAL_EXPORT sp_flush_input_data_impl(VALUE self)
 {
 	BOOL   ret;
 	HANDLE fh;
@@ -618,8 +596,7 @@ VALUE RB_SERIAL_EXPORT sp_flush_input_data_impl(self)
 
 #define PURGE_TXABORT 0x01
 #define PURGE_TXCLEAR 0x04
-VALUE RB_SERIAL_EXPORT sp_flush_output_data_impl(self)
-	VALUE self;
+VALUE RB_SERIAL_EXPORT sp_flush_output_data_impl(VALUE self)
 {
 	BOOL   ret;
 	HANDLE fh;

--- a/ext/native/win_serialport_impl.c
+++ b/ext/native/win_serialport_impl.c
@@ -578,8 +578,12 @@ VALUE RB_SERIAL_EXPORT sp_get_dtr_impl(VALUE self)
    return self;
 }
 
+#ifndef PURGE_RXABORT
 #define PURGE_RXABORT 0x02
+#endif
+#ifndef PURGE_RXCLEAR
 #define PURGE_RXCLEAR 0x08
+#endif
 VALUE RB_SERIAL_EXPORT sp_flush_input_data_impl(VALUE self)
 {
 	BOOL   ret;
@@ -594,8 +598,12 @@ VALUE RB_SERIAL_EXPORT sp_flush_input_data_impl(VALUE self)
 	return Qtrue;
 }
 
+#ifndef PURGE_TXABORT
 #define PURGE_TXABORT 0x01
+#endif
+#ifndef PURGE_TXCLEAR
 #define PURGE_TXCLEAR 0x04
+#endif
 VALUE RB_SERIAL_EXPORT sp_flush_output_data_impl(VALUE self)
 {
 	BOOL   ret;

--- a/lib/serialport.rb
+++ b/lib/serialport.rb
@@ -1,5 +1,4 @@
 require 'serialport.so'
-require 'serialport/version'
 
 
 # This class is used for communication over a serial port.
@@ -7,7 +6,9 @@ require 'serialport/version'
 #
 # @see http://rubydoc.info/stdlib/core/IO Ruby IO class
 # @see http://www.cmrr.umn.edu/~strupp/serial.html "Serial Programming Guide for POSIX Operating Systems"
-class SerialPort
+class SerialPort < IO
+   autoload :VERSION, 'serialport/version'
+
    private_class_method(:create)
 
    # Creates a serial port object.

--- a/lib/serialport/version.rb
+++ b/lib/serialport/version.rb
@@ -1,3 +1,3 @@
-class SerialPort
+class SerialPort < IO
   VERSION = "1.3.2"
 end

--- a/serialport.gemspec
+++ b/serialport.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/serialport/version', __FILE__)
+$: << "lib"
+require "serialport/version"
 
 Gem::Specification.new do |s|
   s.name = "serialport"


### PR DESCRIPTION
I would be willing to maintain this gem, because I have some projects which use it. It's the only serial gem, which can query and set the control pins on Linux and Windows.